### PR TITLE
Higher availability

### DIFF
--- a/helm/teleport-kube-agent/values.yaml
+++ b/helm/teleport-kube-agent/values.yaml
@@ -678,7 +678,7 @@ highAvailability:
   # (via [`authToken`](#authToken), [`joinParams`](#joinParams), or [`joinTokenSecret`](#joinTokenSecret))
   # is still valid. Each replica has its own identity and needs to join the Teleport
   # cluster on its first startup.
-  replicaCount: 2
+  replicaCount: 3
 
   # highAvailability.requireAntiAffinity(bool) -- configures Kubernetes `requiredDuringSchedulingIgnoredDuringExecution`
   # to require that multiple Teleport pods must not be scheduled on the same physical host.
@@ -979,6 +979,14 @@ log:
 # See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
 # for more details.
 affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: teleport-kube-agent
+        topologyKey: "kubernetes.io/hostname"
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
     - preference:

--- a/helm/teleport-kube-agent/values.yaml
+++ b/helm/teleport-kube-agent/values.yaml
@@ -985,7 +985,7 @@ affinity:
       podAffinityTerm:
         labelSelector:
           matchLabels:
-            app.kubernetes.io/name: teleport-kube-agent
+            app: teleport-kube-agent
         topologyKey: "kubernetes.io/hostname"
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->
Towards: https://github.com/giantswarm/roadmap/issues/3564

This PR:

- improves high availability of `teleport-kube-agent-app` on control-plane nodes adding `podAntiAffinity` and scaling up to 3 replicas, one on each master node.

### Testing

Description on how teleport-kube-agent-app can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for teleport-kube-agent-app installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
