### PR TITLE
fix(values): Tolerate `node.cloudprovider.kubernetes.io/uninitialized`.

### DIFF
--- a/helm/teleport-kube-agent/values.yaml
+++ b/helm/teleport-kube-agent/values.yaml
@@ -1344,11 +1344,12 @@ teleport-kube-agent:
   priorityClassName: ""
 
   tolerations:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/control-plane
-    - effect: NoSchedule
-      key: node.cluster.x-k8s.io/uninitialized
-      operator: "Exists"
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+    - key: node.cluster.x-k8s.io/uninitialized
+      effect: NoSchedule
+    - key: node.cloudprovider.kubernetes.io/uninitialized
+      effect: NoSchedule
 
   # probeTimeoutSeconds(int) -- sets the timeout for the readiness and liveness probes
   # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/


### PR DESCRIPTION
This is important for all providers in general, but especially for CAPVCD where we have a slow internet connection, because without that Teleport Kube Agent wouldn't get scheduled until the CCM got deployed, got up and running and initialized the node.

In environments with a fast internet connection this happens quite fast and so the timeout of MC Bootstrap does not strike us.

In environments with a slow internet connection we run into timeouts because fetching the image for the CCM already might take minutes and then fetching the Teleport Kube Agent image took at least 5min in CAPVCD.

Apart of that it might make sense to ignore this taint anyway since there might be situations where we get locked out otherwise.